### PR TITLE
Reducing Required Changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/**
 *.elf
 *.gba
+*.sav

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,10 +12,10 @@
             "postDebugTask": "stop emulation",
             "serverLaunchTimeout": 10000,
             "stopAtEntry": true,
-            "program": "${workspaceRoot}/basic.elf",
+            "program": "${workspaceFolder}/${workspaceFolderBasename}.elf",
             "MIMode": "gdb",
             "externalConsole": true,
-            "cwd": "${workspaceRoot}",
+            "cwd": "${workspaceFolder}",
             "targetArchitecture": "arm",
             "miDebuggerServerAddress": "localhost:2345",
             "windows": {
@@ -24,7 +24,7 @@
                     {
                     "description": "Enable pretty-printing for gdb",
                     "ignoreFailures": true,
-                        "text": "file D:/GitHub/GBA/basic/basic.elf -enable-pretty-printing"
+                        "text": "file ${workspaceFolder}/${workspaceFolderBasename}.elf -enable-pretty-printing"
                     }]
             },
             "osx":{
@@ -33,7 +33,7 @@
                     {
                     "description": "Enable pretty-printing for gdb",
                     "ignoreFailures": true,
-                        "text": "file /Users/jamies/GitHub/GBA/basic/basic.elf -enable-pretty-printing"
+                        "text": "file ${workspaceFolder}/${workspaceFolderBasename}.elf -enable-pretty-printing"
                     }]
             },
         }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -39,11 +39,11 @@
             "dependsOn": ["make debug"],
             "isBackground": false,
             "windows": {
-                "command": "C:/mGBA/mGBA.exe -g ${workspaceFolder}/basic.gba;sleep 5;echo debuggerReady"
+                "command": "C:/mGBA/mGBA.exe -g ${workspaceFolder}/${workspaceFolderBasename}.gba;sleep 5;echo debuggerReady"
             },
             "osx":{
                 "command": "/Users/jamies/mGBA/mGBA.app/Contents/MacOS/mGBA",
-                "args": ["-g", "${workspaceFolder}/basic.gba"]
+                "args": ["-g", "${workspaceFolder}/${workspaceFolderBasename}.gba"]
             },
             "presentation": {
                 "clear": true,
@@ -63,7 +63,7 @@
             "label": "run",
             "type": "shell",
             "isBackground": true,
-            "command": "C:/NO$GBADebugger/NO$GBA.exe  ${workspaceFolder}/basic.elf",
+            "command": "C:/NO$GBADebugger/NO$GBA.exe  ${workspaceFolder}/${workspaceFolderBasename}.elf",
             "problemMatcher": []
         }
     ]

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Once devKitPro has done it's thing you can move on to getting VS Code set up.
 
 **launch.json** - There are a few modifications to be made here, again surrounding where you have installed devkitPro to on your machine. 
   - Line 19 the location that *miDebuggerPath* points to will need to change to reflect your devkitPro installation folder path.
-  - Line 24 will need to change to point the debugger to the folder that the basic.elf is built into, so wherever you have cloned this repo to.
   
 **tasks.json** - line 29 will need to change to reflect where you have installed mGBA. Only the first part of this line needs to change up to the call to the exe. The latter half of the line need not change. 
 Line 35 may need to change, or you can remove the whole **run** label if you choose to. I sometimes use No$GBA as the source debugger is pretty great.


### PR DESCRIPTION
Making use of Visual Studio Code's built in variables to reduce the number of changes needed for tasks.json and launch.json. This allows the project folder to be used as a template (copied and renamed) once the debugger path and emulator path have been set.
-The output file names now match the files output by the makefile (match the folder name).
-replaced deprecated ${workspaceRoot} with ${workspaceFolder}
-removed the unnecessary change description from the README
-added .sav files to gitignore